### PR TITLE
CM-182: 🔨 swagger-ui 깨지는 오류 수정

### DIFF
--- a/app/api-doc/page.tsx
+++ b/app/api-doc/page.tsx
@@ -1,10 +1,10 @@
 import { getApiDocs } from "@/utils/swagger";
 import ReactSwagger from "./react-swagger";
-
+import styles from './reset.module.css';
 export default async function IndexPage() {
-  const spec = await getApiDocs();
+  const spec = await getApiDocs();  
   return (
-    <section className="container">
+    <section className={styles.resetContainer}>
       <ReactSwagger spec={spec} />
     </section>
   );

--- a/app/api-doc/reset.module.css
+++ b/app/api-doc/reset.module.css
@@ -1,0 +1,6 @@
+.resetContainer,
+.resetContainer * {
+    font-family: unset;
+    width:auto;
+}
+

--- a/utils/swagger.ts
+++ b/utils/swagger.ts
@@ -6,19 +6,13 @@ export const getApiDocs = async () => {
     definition: {
       openapi: "3.0.0",
       info: {
-        title: "Next Swagger API Example",
+        title: "Clmap API DOC",
         version: "1.0",
       },
       components: {
         securitySchemes: {
-          BearerAuth: {
-            type: "http",
-            scheme: "bearer",
-            bearerFormat: "JWT",
-          },
         },
       },
-      security: [],
     },
   });
   return spec;


### PR DESCRIPTION
## 🔍️ 작업 상세 내용

> 작업 내용에 대해 자세히 작성해주세요.

- swagger ui가 깨지는 오류를 수정했습니다. global.css가 형향을 줘서 swagger-ui의 기본 컴포넌트들이 다르게 동작했었습니다. 컴포넌트의 하위에 영향을 주는 css를 만들어서 해결했습니다.

## 🙏 요청 및 질문사항

> 요청 및 질문사항이 있다면 작성해주세요.

- PR 폭격 날릴건데 미리 죄송합니다

## 📷 스크린샷

> 간단한 스크린샷을 첨부해주세요.

![image](https://github.com/user-attachments/assets/a1f6eedf-5631-453b-a00d-ed030da9c162)

